### PR TITLE
Fix redirect bug to /# that occurs on some browsers

### DIFF
--- a/Chapter 10/3285OS_10_01/public/application.js
+++ b/Chapter 10/3285OS_10_01/public/application.js
@@ -17,6 +17,10 @@ mainApplicationModule.config(['$locationProvider',
 // Fix Facebook's OAuth bug
 if (window.location.hash === '#_=_') window.location.hash = '#!';
 
+// Fix redirect bug to /# that happens on some browsers
+
+if (window.location.href.slice(-1) === '#') window.location.hash = "#!";
+
 // Manually bootstrap the AngularJS application
 angular.element(document).ready(function() {
 	angular.bootstrap(document, [mainApplicationModuleName]);

--- a/Chapter 11/3285OS_11_01/public/application.js
+++ b/Chapter 11/3285OS_11_01/public/application.js
@@ -17,6 +17,10 @@ mainApplicationModule.config(['$locationProvider',
 // Fix Facebook's OAuth bug
 if (window.location.hash === '#_=_') window.location.hash = '#!';
 
+//Fix redirect bug to /# that happens on some browsers
+
+if (window.location.href.slice(-1) === '#') window.location.hash = "#!";
+
 // Manually bootstrap the AngularJS application
 angular.element(document).ready(function() {
 	angular.bootstrap(document, [mainApplicationModuleName]);

--- a/Chapter 7/3285OS_07_01/public/application.js
+++ b/Chapter 7/3285OS_07_01/public/application.js
@@ -17,6 +17,10 @@ mainApplicationModule.config(['$locationProvider',
 // Fix Facebook's OAuth bug
 if (window.location.hash === '#_=_') window.location.hash = '#!';
 
+// Fix redirect bug to /# that happens on some browsers
+
+if (window.location.href.slice(-1) === '#') window.location.hash = "#!";
+
 // Manually bootstrap the AngularJS application
 angular.element(document).ready(function() {
 	angular.bootstrap(document, [mainApplicationModuleName]);

--- a/Chapter 8/3285OS_08_01/public/application.js
+++ b/Chapter 8/3285OS_08_01/public/application.js
@@ -17,6 +17,10 @@ mainApplicationModule.config(['$locationProvider',
 // Fix Facebook's OAuth bug
 if (window.location.hash === '#_=_') window.location.hash = '#!';
 
+// Fix redirect bug to /# that happens on some browsers
+
+if (window.location.href.slice(-1) === '#') window.location.hash = "#!";
+
 // Manually bootstrap the AngularJS application
 angular.element(document).ready(function() {
 	angular.bootstrap(document, [mainApplicationModuleName]);

--- a/Chapter 9/3285OS_09_01/public/application.js
+++ b/Chapter 9/3285OS_09_01/public/application.js
@@ -17,6 +17,10 @@ mainApplicationModule.config(['$locationProvider',
 // Fix Facebook's OAuth bug
 if (window.location.hash === '#_=_') window.location.hash = '#!';
 
+// Fix redirect bug to /# that happens on some browsers
+
+if (window.location.href.slice(-1) === '#') window.location.hash = "#!";
+
 // Manually bootstrap the AngularJS application
 angular.element(document).ready(function() {
 	angular.bootstrap(document, [mainApplicationModuleName]);


### PR DESCRIPTION
Hi Amos,

Great work on the book, I learned a tremendous amount!  I built out an app from the book and life was good.  I checked back in about 6 weeks later on Chrome, and I came across the same bug described here: https://github.com/linnovate/mean/issues/192, when trying to login with Google.  It only happened on Chrome, and it became an issue only in the last 6 weeks as I had done all my development on Chrome.  Anyways, I implemented the fix described in the issue successfully, and I think it would be really valuable to include it in your repo since you include a fix for the Facebook redirect anyways.  This problem completely befuddled me for a couple of hours (everything was working in Firefox and Safari), and would be maddening for someone to debug when they are working through your book...

Thanks again for your work!
